### PR TITLE
adding an exception try except when bulk indexor throws an error

### DIFF
--- a/wiki-es-dump/upload.py
+++ b/wiki-es-dump/upload.py
@@ -21,7 +21,10 @@ def upload_partition(partition):
         '_type': '_doc',
         '_source' : article
     } for index, article in partition)
-    bulk(es, actions)
+    try:
+        bulk(es, actions)
+    except elasticsearch.helpers.errors.BulkIndexError as error:
+        print('Bulk Index Error in partition: ' + str(error))
 
 if __name__ == "__main__":
     conf = SparkConf().setAppName('wiki-parse').set('spark.driver.maxResultSize', 0)


### PR DESCRIPTION
I have added a try-except around the bulk call. A couple of points to note:

1. If the bulk call fails for a particular partition, the execution for that partition is stopped so no further execution on that.
2. I used print instead of logging because logging does not get initiated in this file.
3. There is an extra line in the commit (for each partition), but it is redundant. If you feel this needs to be removed, let me know.